### PR TITLE
Duel TNT Laser fixes

### DIFF
--- a/datapacks/map/data/game/functions/items/laser.mcfunction
+++ b/datapacks/map/data/game/functions/items/laser.mcfunction
@@ -1,4 +1,6 @@
-execute as @s[scores={laserDummy=10..}] at @s run tp @s @s
+execute as @s[scores={laserDummy=30}] at @s rotated ~ ~ run summon marker ^ ^ ^ {Tags:["stay_put"]}
+execute as @s[scores={laserDummy=30}] at @s run tp @e[type=marker,tag=stay_put,limit=1,sort=nearest] @s
+execute as @s[scores={laserDummy=10..}] at @s run tp @s @e[type=marker,tag=stay_put,limit=1,sort=nearest]
 execute as @s[scores={laserDummy=10..}] at @s run particle minecraft:enchanted_hit ~ ~1 ~ 0 0 0 1.2 3
 
 execute as @s[scores={laserDummy=30..}] at @s run clear @s rabbit_hide
@@ -17,14 +19,14 @@ execute as @s[scores={laserDummy=17}] at @s run execute as @a[distance=..80] at 
 execute as @s[scores={laserDummy=17}] at @s run execute as @a[distance=..80] at @s run playsound minecraft:entity.firework_rocket.launch master @a[distance=..50] ~ ~ ~ 1 1.2
 
 execute as @s[scores={laserDummy=30}] at @s run summon armor_stand ~ ~ ~ {Tags:["wbeam"]}
-execute as @s[scores={laserDummy=30}] at @s run tp @e[tag=wbeam] @s
+execute as @s[scores={laserDummy=30}] at @s run tp @e[tag=wbeam] @e[type=marker,tag=stay_put,limit=1,sort=nearest]
 execute as @s[scores={laserDummy=30}] at @s run scoreboard players set @e[tag=wbeam] laserDummy 300
 execute as @s[scores={laserDummy=30}] at @s run execute as @e[tag=wbeam] at @s run function game:items/whitebeam
 
 execute as @s[scores={laserDummy=17}] at @s run tag @e remove beamhit
 tag @s[scores={laserDummy=17}] add nohit
 execute as @s[scores={laserDummy=17}] at @s run summon armor_stand ~ ~ ~ {Tags:["wbeam"]}
-execute as @s[scores={laserDummy=17}] at @s run tp @e[tag=wbeam] @s
+execute as @s[scores={laserDummy=17}] at @s run tp @e[tag=wbeam] @e[type=marker,tag=stay_put,limit=1,sort=nearest]
 execute as @s[scores={laserDummy=17}] at @s run scoreboard players set @e[tag=wbeam] laserDummy 300
 execute as @s[scores={laserDummy=17}] at @s run tag @a[gamemode=spectator] add spectest
 execute as @s[scores={laserDummy=17}] at @s run execute as @e[tag=wbeam] at @s run function game:items/redbeam
@@ -39,6 +41,7 @@ execute as @s[scores={laserDummy=17}] at @s run execute as @e[tag=beamhit,type=g
 execute as @s[scores={laserDummy=17}] at @s run execute as @e[tag=beamhit,type=chicken] at @s run function game:items/beamhit
 execute as @s[scores={laserDummy=17}] at @s run execute as @e[tag=beamhit,type=slime] at @s run function game:items/beamhit
 execute as @s[scores={laserDummy=17}] at @s run damage @e[tag=beamhit,type=wither,limit=1] 200 minecraft:arrow
+execute as @s[scores={laserDummy=17}] at @s run kill @e[type=marker,tag=stay_put,limit=1,sort=nearest]
 
 execute as @s[scores={laserDummy=-230}] at @s run function game:player/class_team
 execute as @s[scores={laserDummy=-230}] at @s run tellraw @a[gamemode=spectator] [{"selector":"@s"},{"text":" Reloaded ","color":"white"},{"text":"Laser","color":"red","bold":"true"}]

--- a/datapacks/map/data/game/functions/items/laser.mcfunction
+++ b/datapacks/map/data/game/functions/items/laser.mcfunction
@@ -1,9 +1,9 @@
 execute as @s[scores={laserDummy=30}] at @s rotated ~ ~ run summon marker ~ ~ ~ {Tags:["stay_put"]}
 execute as @s[scores={laserDummy=30}] at @s run tp @e[type=marker,tag=stay_put,limit=1,sort=nearest] @s
 execute as @s[scores={laserDummy=30}] at @s run scoreboard players operation @e[type=marker,tag=stay_put,limit=1,sort=nearest] tntID = @s tntID
-execute as @s[scores={laserDummy=10..}] at @s run tp @s @s 
 execute as @s[scores={laserDummy=10..}] at @s as @e[type=marker,tag=stay_put] if score @s tntID = @p tntID run tag @s add you_are_my_owner
 execute as @s[scores={laserDummy=10..}] at @s rotated as @e[tag=you_are_my_owner] run tp @e[tag=you_are_my_owner] ~ ~ ~
+execute as @s[scores={laserDummy=10..}] run tp @s @e[tag=you_are_my_owner,sort=nearest,limit=1]
 execute as @s[scores={laserDummy=10..}] at @s run particle minecraft:enchanted_hit ~ ~1 ~ 0 0 0 1.2 3
 
 execute as @s[scores={laserDummy=30..}] at @s run clear @s rabbit_hide

--- a/datapacks/map/data/game/functions/items/laser.mcfunction
+++ b/datapacks/map/data/game/functions/items/laser.mcfunction
@@ -1,6 +1,9 @@
-execute as @s[scores={laserDummy=30}] at @s rotated ~ ~ run summon marker ^ ^ ^ {Tags:["stay_put"]}
+execute as @s[scores={laserDummy=30}] at @s rotated ~ ~ run summon marker ~ ~ ~ {Tags:["stay_put"]}
 execute as @s[scores={laserDummy=30}] at @s run tp @e[type=marker,tag=stay_put,limit=1,sort=nearest] @s
-execute as @s[scores={laserDummy=10..}] at @s run tp @s @e[type=marker,tag=stay_put,limit=1,sort=nearest]
+execute as @s[scores={laserDummy=30}] at @s run scoreboard players operation @e[type=marker,tag=stay_put,limit=1,sort=nearest] tntID = @s tntID
+execute as @s[scores={laserDummy=10..}] at @s run tp @s @s 
+execute as @s[scores={laserDummy=10..}] at @s as @e[type=marker,tag=stay_put] if score @s tntID = @p tntID run tag @s add you_are_my_owner
+execute as @s[scores={laserDummy=10..}] at @s rotated as @e[tag=you_are_my_owner] run tp @e[tag=you_are_my_owner] ~ ~ ~
 execute as @s[scores={laserDummy=10..}] at @s run particle minecraft:enchanted_hit ~ ~1 ~ 0 0 0 1.2 3
 
 execute as @s[scores={laserDummy=30..}] at @s run clear @s rabbit_hide
@@ -19,14 +22,14 @@ execute as @s[scores={laserDummy=17}] at @s run execute as @a[distance=..80] at 
 execute as @s[scores={laserDummy=17}] at @s run execute as @a[distance=..80] at @s run playsound minecraft:entity.firework_rocket.launch master @a[distance=..50] ~ ~ ~ 1 1.2
 
 execute as @s[scores={laserDummy=30}] at @s run summon armor_stand ~ ~ ~ {Tags:["wbeam"]}
-execute as @s[scores={laserDummy=30}] at @s run tp @e[tag=wbeam] @e[type=marker,tag=stay_put,limit=1,sort=nearest]
+execute as @s[scores={laserDummy=30}] at @s run tp @e[tag=wbeam,limit=1] @s
 execute as @s[scores={laserDummy=30}] at @s run scoreboard players set @e[tag=wbeam] laserDummy 300
 execute as @s[scores={laserDummy=30}] at @s run execute as @e[tag=wbeam] at @s run function game:items/whitebeam
 
 execute as @s[scores={laserDummy=17}] at @s run tag @e remove beamhit
 tag @s[scores={laserDummy=17}] add nohit
 execute as @s[scores={laserDummy=17}] at @s run summon armor_stand ~ ~ ~ {Tags:["wbeam"]}
-execute as @s[scores={laserDummy=17}] at @s run tp @e[tag=wbeam] @e[type=marker,tag=stay_put,limit=1,sort=nearest]
+execute as @s[scores={laserDummy=17}] at @s run tp @e[tag=wbeam,limit=1] @e[tag=you_are_my_owner,limit=1,sort=nearest]
 execute as @s[scores={laserDummy=17}] at @s run scoreboard players set @e[tag=wbeam] laserDummy 300
 execute as @s[scores={laserDummy=17}] at @s run tag @a[gamemode=spectator] add spectest
 execute as @s[scores={laserDummy=17}] at @s run execute as @e[tag=wbeam] at @s run function game:items/redbeam
@@ -47,4 +50,5 @@ execute as @s[scores={laserDummy=-230}] at @s run function game:player/class_tea
 execute as @s[scores={laserDummy=-230}] at @s run tellraw @a[gamemode=spectator] [{"selector":"@s"},{"text":" Reloaded ","color":"white"},{"text":"Laser","color":"red","bold":"true"}]
 item replace entity @s[scores={laserDummy=-230}] hotbar.4 with rabbit_hide{display:{Name:"{\"italic\":false,\"text\":\"§4Laser §r: Right-click\"}"}}
 
+tag @e remove im_your_owner
 scoreboard players remove @s laserDummy 1

--- a/datapacks/map/data/game/functions/items/redbeam.mcfunction
+++ b/datapacks/map/data/game/functions/items/redbeam.mcfunction
@@ -1,17 +1,7 @@
-tp @s ^ ^ ^.3
 particle minecraft:block minecraft:redstone_block ~ ~1.3 ~ .1 .1 .1 2 4 force
 scoreboard players remove @s laserDummy 1
 tag @e[tag=beamhit1] remove beamhit1
-execute as @s at @s positioned ~0.2 ~1.6 ~0.2 run tag @e[tag=!spectest,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=0] add beamhit
-execute as @s at @s positioned ~-0.2 ~1.6 ~0.2 run tag @e[tag=!spectest,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=0] add beamhit
-execute as @s at @s positioned ~0.2 ~1.6 ~-0.2 run tag @e[tag=!spectest,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=0] add beamhit
-execute as @s at @s positioned ~-0.2 ~1.6 ~-0.2 run tag @e[tag=!spectest,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=0] add beamhit
-execute as @s at @s positioned ~0.2 ~1.2 ~0.2 run tag @e[tag=!spectest,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=0] add beamhit
-execute as @s at @s positioned ~-0.2 ~1.2 ~0.2 run tag @e[tag=!spectest,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=0] add beamhit
-execute as @s at @s positioned ~0.2 ~1.2 ~-0.2 run tag @e[tag=!spectest,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=0] add beamhit
-execute as @s at @s positioned ~-0.2 ~1.2 ~-0.2 run tag @e[tag=!spectest,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=0] add beamhit
-execute as @s at @s positioned ~-.2 ~0.9 ~-.2 run tag @e[tag=!spectest,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=1] add beamhit1
-execute as @s at @s positioned ~-.8 ~-0.4 ~-.8 run tag @e[tag=!spectest,tag=beamhit1,tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=1] add beamhit
+execute as @e[tag=!spectest,tag=!nohit,tag=!wbeam] positioned ~-.2 ~-.2 ~-.2 if entity @s[dx=.4,dy=.4,dz=.4] run tag @s add beamhit
 execute as @s at @s positioned ~ ~1.4 ~ run function game:physics/inblock
-execute as @s[tag=in,scores={laserDummy=1..}] at @s run function game:items/redbeam
+execute as @s[tag=in,scores={laserDummy=1..}] positioned ^ ^ ^.3 run function game:items/redbeam
 kill @s

--- a/datapacks/map/data/game/functions/items/whitebeam.mcfunction
+++ b/datapacks/map/data/game/functions/items/whitebeam.mcfunction
@@ -1,7 +1,6 @@
-tp @s ^ ^ ^.3
 particle minecraft:spit ~ ~1.3 ~ 0 0 0 0 1 force
 scoreboard players remove @s laserDummy 1
 #execute as @s at @s positioned ~-.5 ~-0.7 ~-.5 run tag @e[tag=!nohit,tag=!wbeam,distance=..3,dx=0,dz=0,dy=1] add beamhit
 execute as @s at @s positioned ~ ~1.4 ~ run function game:physics/inblock
-execute as @s[tag=in,scores={laserDummy=1..}] at @s run function game:items/whitebeam
+execute as @s[tag=in,scores={laserDummy=1..}] positioned ^ ^ ^.3 run function game:items/whitebeam
 kill @s


### PR DESCRIPTION
Fixed the laser desync bug, and the hitbox being skewed 1.5 blocks to the positive x,y,z coordinates